### PR TITLE
feat: add custom exception error handling

### DIFF
--- a/python/src/greenbids/tailor/core/app/exceptions.py
+++ b/python/src/greenbids/tailor/core/app/exceptions.py
@@ -2,13 +2,20 @@ from fastapi import Request, HTTPException, status
 from greenbids.tailor.core.app import resources
 import typing
 
+import logging
+
+_logger = logging.getLogger(__name__)
+
 
 async def model_not_ready_handler(request: Request, exc: resources.ModelNotReady):
-    del request
+    if not (request.method == "GET" and "healthz" in request.url.path):
+        _logger.warning(
+            "An access to the prediction model has been made, while it is not ready yet."
+        )
     raise HTTPException(
-        status_code=status.HTTP_425_TOO_EARLY,
+        status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
         detail="Model is not ready yet. Check readiness on route /healthz/readiness. Retry in few seconds.",
-        headers={"gb-tailor-model-name": exc.model_name},
+        headers={"gb-tailor-model-name": exc.model_name, "Retry-After": str(15)},
     )
 
 

--- a/python/src/greenbids/tailor/core/app/exceptions.py
+++ b/python/src/greenbids/tailor/core/app/exceptions.py
@@ -1,4 +1,5 @@
 from fastapi import Request, HTTPException, status
+from greenbids.tailor.core import fabric, models
 from greenbids.tailor.core.app import resources
 import typing
 
@@ -19,9 +20,27 @@ async def model_not_ready_handler(request: Request, exc: resources.ModelNotReady
     )
 
 
+async def unexpected_report_handler(request: Request, exc: models.UnexpectedReport):
+    import pydantic
+
+    del request
+
+    ta = pydantic.TypeAdapter(list[fabric.Fabric])
+    _logger.debug(
+        "Report unexpected for the following request:\n"
+        + str(ta.dump_python(exc.fabrics, exclude_defaults=True)),
+        exc_info=exc,
+    )
+    raise HTTPException(
+        status_code=status.HTTP_202_ACCEPTED,
+        detail="Request has been discarded as it was not expected to be used for report.",
+    )
+
+
 EXCEPTION_HANDLERS: dict[
     typing.Union[int, type[Exception]],
     typing.Callable[[Request, typing.Any], typing.Coroutine],
 ] = {
     resources.ModelNotReady: model_not_ready_handler,
+    models.UnexpectedReport: unexpected_report_handler,
 }

--- a/python/src/greenbids/tailor/core/app/exceptions.py
+++ b/python/src/greenbids/tailor/core/app/exceptions.py
@@ -1,4 +1,4 @@
-from fastapi import Request, HTTPException, status
+from fastapi import Request, HTTPException, status, responses
 from greenbids.tailor.core import fabric, models
 from greenbids.tailor.core.app import resources
 import typing
@@ -31,9 +31,9 @@ async def unexpected_report_handler(request: Request, exc: models.UnexpectedRepo
         + str(ta.dump_python(exc.fabrics, exclude_defaults=True)),
         exc_info=exc,
     )
-    raise HTTPException(
+    return responses.JSONResponse(
+        exc.fabrics,
         status_code=status.HTTP_202_ACCEPTED,
-        detail="Request has been discarded as it was not expected to be used for report.",
     )
 
 

--- a/python/src/greenbids/tailor/core/app/exceptions.py
+++ b/python/src/greenbids/tailor/core/app/exceptions.py
@@ -1,0 +1,20 @@
+from fastapi import Request, HTTPException, status
+from greenbids.tailor.core.app import resources
+import typing
+
+
+async def model_not_ready_handler(request: Request, exc: resources.ModelNotReady):
+    del request
+    raise HTTPException(
+        status_code=status.HTTP_425_TOO_EARLY,
+        detail="Model is not ready yet. Check readiness on route /healthz/readiness. Retry in few seconds.",
+        headers={"gb-tailor-model-name": exc.model_name},
+    )
+
+
+EXCEPTION_HANDLERS: dict[
+    typing.Union[int, type[Exception]],
+    typing.Callable[[Request, typing.Any], typing.Coroutine],
+] = {
+    resources.ModelNotReady: model_not_ready_handler,
+}

--- a/python/src/greenbids/tailor/core/app/main.py
+++ b/python/src/greenbids/tailor/core/app/main.py
@@ -6,7 +6,7 @@ from fastapi import FastAPI
 from greenbids.tailor.core import telemetry
 from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
 
-from . import profiler, resources, tasks
+from . import profiler, resources, tasks, exceptions
 from .routers import healthz, ping, root
 
 _logger = logging.getLogger(__name__)
@@ -40,6 +40,7 @@ app = FastAPI(
     description=str(pkg_dist.metadata.json.get("description")),
     version=pkg_dist.version,
     lifespan=_lifespan,
+    exception_handlers=exceptions.EXCEPTION_HANDLERS,
 )
 FastAPIInstrumentor.instrument_app(
     app,

--- a/python/src/greenbids/tailor/core/app/resources.py
+++ b/python/src/greenbids/tailor/core/app/resources.py
@@ -24,7 +24,10 @@ def _default_refresh_period() -> datetime.timedelta:
     )
 
 
-class ModelNotReady(AttributeError): ...
+class ModelNotReady(AttributeError):
+    def __init__(self, *args: object, model_name: str, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.model_name = model_name
 
 
 class AppResources(pydantic.BaseModel):
@@ -52,7 +55,9 @@ class AppResources(pydantic.BaseModel):
     @property
     def gb_model(self) -> models.Model:
         if self._gb_model is None:
-            raise ModelNotReady(name=f"gb_model({self.gb_model_name})", obj=self)
+            raise ModelNotReady(
+                model_name=self.gb_model_name, name="gb_model", obj=self
+            )
         return self._gb_model
 
     @pydantic.computed_field
@@ -64,11 +69,6 @@ class AppResources(pydantic.BaseModel):
     @property
     def core_version(self) -> str:
         return version
-
-    @pydantic.computed_field
-    @property
-    def is_ready(self) -> bool:
-        return self._gb_model is not None
 
     def refresh_model(self) -> None:
         kwargs = {}

--- a/python/src/greenbids/tailor/core/app/resources.py
+++ b/python/src/greenbids/tailor/core/app/resources.py
@@ -70,6 +70,11 @@ class AppResources(pydantic.BaseModel):
     def core_version(self) -> str:
         return version
 
+    @pydantic.computed_field
+    @property
+    def is_ready(self) -> bool:
+        return self._gb_model is not None
+
     def refresh_model(self) -> None:
         kwargs = {}
         try:

--- a/python/src/greenbids/tailor/core/app/routers/healthz.py
+++ b/python/src/greenbids/tailor/core/app/routers/healthz.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, HTTPException, status
+from fastapi import APIRouter
 from greenbids.tailor.core.app import resources
 
 router = APIRouter(prefix="/healthz", tags=["Health check"])

--- a/python/src/greenbids/tailor/core/app/routers/healthz.py
+++ b/python/src/greenbids/tailor/core/app/routers/healthz.py
@@ -20,6 +20,5 @@ async def liveness_probe() -> resources.AppResources:
 async def readiness_probe() -> resources.AppResources:
     """Determine when a container is ready to start accepting traffic."""
     instance = resources.get_instance()
-    if not instance.is_ready:
-        raise HTTPException(status_code=status.HTTP_425_TOO_EARLY)
+    _ = instance.gb_model
     return instance

--- a/python/src/greenbids/tailor/core/fabric.py
+++ b/python/src/greenbids/tailor/core/fabric.py
@@ -77,3 +77,13 @@ class Fabric(_CamelSerialized):
     feature_map: FeatureMap = pydantic.Field(default_factory=FeatureMap)
     prediction: Prediction = pydantic.Field(default_factory=Prediction)
     ground_truth: GroundTruth = pydantic.Field(default_factory=GroundTruth)
+
+
+def should_report(fabrics: list[Fabric]) -> bool:
+    """Does a request should be sent to report endpoints.
+
+    Returns `True` if **all** fabrics are exploration and training one, else `False`.
+    """
+    return not all(
+        not (f.prediction.is_exploration and f.prediction.is_training) for f in fabrics
+    )

--- a/python/src/greenbids/tailor/core/fabric.py
+++ b/python/src/greenbids/tailor/core/fabric.py
@@ -82,8 +82,8 @@ class Fabric(_CamelSerialized):
 def should_report(fabrics: list[Fabric]) -> bool:
     """Does a request should be sent to report endpoints.
 
-    Returns `True` if **all** fabrics are exploration and training one, else `False`.
+    Returns `True` if **all (and at least one)** fabrics are exploration and training one, else `False`.
     """
-    return not all(
-        not (f.prediction.is_exploration and f.prediction.is_training) for f in fabrics
+    return fabrics and all(
+        (f.prediction.is_exploration and f.prediction.is_training) for f in fabrics
     )

--- a/python/src/greenbids/tailor/core/models.py
+++ b/python/src/greenbids/tailor/core/models.py
@@ -13,6 +13,14 @@ from greenbids.tailor.core import fabric
 _logger = logging.getLogger(__name__)
 
 
+class UnexpectedReport(ValueError):
+    """Raised when the report was called while it is not expected."""
+
+    def __init__(self, *args: object, fabrics: list[fabric.Fabric]) -> None:
+        super().__init__(*args)
+        self.fabrics = fabrics
+
+
 class Model(ABC):
 
     @abstractmethod
@@ -54,6 +62,8 @@ class NullModel(Model):
         self,
         fabrics: list[fabric.Fabric],
     ) -> list[fabric.Fabric]:
+        if not fabric.should_report(fabrics):
+            raise UnexpectedReport(fabrics=fabrics)
         self._logger.debug([f.feature_map.root for f in fabrics[:1]])
         return fabrics
 

--- a/python/tests/test_fabric.py
+++ b/python/tests/test_fabric.py
@@ -1,0 +1,21 @@
+import unittest
+
+from greenbids.tailor.core import fabric
+
+
+class TestFabrics(unittest.TestCase):
+
+    def test_should_report_if_all_inputs_are_training(self):
+        trainable = fabric.Fabric(
+            prediction=fabric.Prediction(exploration_rate=1, training_rate=1)
+        )
+        non_trainable = fabric.Fabric(
+            prediction=fabric.Prediction(exploration_rate=0, training_rate=0)
+        )
+
+        with self.subTest("Empty should not be reported: [] => False"):
+            self.assertFalse(fabric.should_report([]))
+        with self.subTest("Any non-training should not be reported: [T, F] => False"):
+            self.assertFalse(fabric.should_report([trainable, non_trainable]))
+        with self.subTest("All training should be reported: [T, T] => T"):
+            self.assertTrue(fabric.should_report([trainable, trainable]))


### PR DESCRIPTION
Example of returned response if model is not ready:

```
# curl -v -X PUT --json '[{}]' http://localhost:8000
[...]
* upload completely sent off: 4 bytes
< HTTP/1.1 503 Service Unavailable
< date: Wed, 06 Nov 2024 12:41:14 GMT
< server: uvicorn
< gb-tailor-model-name: scikit
< retry-after: 15
< content-length: 103
< content-type: application/json
< 
* Connection #0 to host localhost left intact
{"detail":"Model is not ready yet. Check readiness on route /healthz/readiness. Retry in few seconds."}%                      
```

It highlights:
* the status code used: ~~[HTTP 425](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/425)~~ [HTTP 503](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/503)
* the error message (not ready, use readiness probe, retry later)
* the custom header for model tried to be loaded (is it relevant ?)
* standard header for retry delay

On the server side it just print a warning log:
```
WARNING:greenbids.tailor.core.app.exceptions:An access to the prediction model has been made, while it is not ready yet.
```