### PR TITLE
feat(helm)!: expose otelExporterPrometheus configuration in the values file

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -35,8 +35,14 @@ spec:
           envFrom:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- with .Values.env }}
           env:
+          {{- if .Values.otelExporterPrometheus.enabled }}
+            - name: OTEL_EXPORTER_PROMETHEUS_ENABLED
+              value: true
+            - name: OTEL_EXPORTER_PROMETHEUS_PORT
+              value: {{ .Values.otelExporterPrometheus.targetPort }}
+          {{- end }}
+          {{- with .Values.env }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
           ports:

--- a/chart/templates/service.yaml
+++ b/chart/templates/service.yaml
@@ -11,11 +11,11 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
-    {{- if .Values.env.OTEL_EXPORTER_PROMETHEUS_ENABLED }}
-    - port: {{ .Values.env.OTEL_EXPORTER_PROMETHEUS_PORT | default 9464 }}
-      targetPort: http
+  {{- if .Values.otelExporterPrometheus.enabled }}
+    - port: {{ .Values.otelExporterPrometheus.port }}
+      targetPort: {{ .Values.otelExporterPrometheus.targetPort }}
       protocol: TCP
       name: prom
-    {{- end }}
+  {{- end }}
   selector:
     {{- include "greenbids-tailor.selectorLabels" . | nindent 4 }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -84,4 +84,10 @@ affinity: {}
 env:
   - name: WEB_CONCURRENCY
     value: "1"
+
 envFrom: []
+
+otelExporterPrometheus:
+  enabled: false
+  port: 9464
+  targetPort: 9464


### PR DESCRIPTION
Exposing the deployment’s native environment API breaks the Prometheus exporter configuration in the service, causing `helm template .` to fail.

This PR fixes this, by moving the Prometheus configuration from environment variables to values.yaml.

Additionally, this PR fixes an error in the Prometheus service endpoint definition. The targetPort was pointing to the container’s http port (80) instead of the port where the Prometheus exporter endpoint is exposed.