### PR TITLE
feat(chart): add support for HPA behavior configuration

### DIFF
--- a/chart/templates/hpa.yaml
+++ b/chart/templates/hpa.yaml
@@ -29,4 +29,8 @@ spec:
           type: Utilization
           averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
     {{- end }}
+  {{- with .Values.autoscaling.behavior }}
+  behavior:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -75,6 +75,9 @@ autoscaling:
   maxReplicas: 100
   targetCPUUtilizationPercentage: 80
   # targetMemoryUtilizationPercentage: 80
+  # behavior: 
+  #   scaleDown:
+  #     stabilizationWindowSeconds: 86400
 
 nodeSelector: {}
 


### PR DESCRIPTION
Expose optional HPA behavior in the Helm chart so scale-up/scale-down policies (e.g. stabilization windows) can be set via values

Tested by rendering the chart with and without `autoscaling.behavior` and confirm the HPA spec matches